### PR TITLE
Throttle get safe element size

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -263,6 +263,9 @@
   * @property {Boolean} [autoResize=true]
   *     Set to false to prevent polling for viewer size changes. Useful for providing custom resize behavior.
   *
+  * @property {Number} [autoResizeInterval=5000]
+  *     How often polling for viewer size should occur. This requires autoResize=true (default).
+  *
   * @property {Boolean} [preserveImageSizeOnResize=false]
   *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
   *
@@ -1138,6 +1141,7 @@ function OpenSeadragon( options ){
             pixelsPerWheelLine:     40,
             pixelsPerArrowPress:    40,
             autoResize:             true,
+            autoResizeInterval:     5000,
             preserveImageSizeOnResize: false, // requires autoResize=true
             minScrollDeltaTime:     50,
             rotationIncrement:      90,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2260,17 +2260,35 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
 /**
  * _getSafeElemSize is like getElementSize(), but refuses to return 0 for x or y,
- * which was causing some calling operations to return NaN.
+ * which was causing some calling operations to return NaN. Function won't recalculate
+ * element's size more than once every 5s
  * @returns {Point}
  * @private
  */
 function _getSafeElemSize (oElement) {
-    oElement = $.getElement( oElement );
+    if(oElement.oldClientWidth !== undefined && oElement.oldClientHeight !== undefined){
+        var safeSize = new $.Point(oElement.oldClientWidth, oElement.oldClientHeight);
 
-    return new $.Point(
-        (oElement.clientWidth === 0 ? 1 : oElement.clientWidth),
-        (oElement.clientHeight === 0 ? 1 : oElement.clientHeight)
-    );
+        var currentTime = new Date().getTime();
+        if(currentTime - oElement.recentCalculationTime > 10000){
+            delete oElement.oldClientWidth;
+            delete oElement.oldClientHeight;
+        }
+
+        return safeSize;
+    } else {
+        var joElement = $.getElement( oElement );
+
+        var clientWidth = joElement.clientWidth === 0 ? 1 : joElement.clientWidth;
+        var clientHeight = joElement.clientHeight === 0 ? 1 : joElement.clientHeight;
+
+        var recentTime = new Date().getTime();
+        oElement.recentCalculationTime = recentTime;
+        oElement.oldClientWidth = clientWidth;
+        oElement.oldClientHeight = clientHeight;
+
+        return new $.Point(clientWidth, clientHeight);
+    }
 }
 
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -319,7 +319,7 @@ $.Viewer = function( options ) {
 
     this.bindStandardControls();
 
-    THIS[ this.hash ].prevContainerSize = _getSafeElemSize( this.container );
+    THIS[ this.hash ].prevContainerSize = _getSafeElemSize( this.container, 0 );
 
     // Create the world
     this.world = new $.World({
@@ -2260,17 +2260,17 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
 
 /**
  * _getSafeElemSize is like getElementSize(), but refuses to return 0 for x or y,
- * which was causing some calling operations to return NaN. Function won't recalculate
- * element's size more than once every 5s
+ * which was causing some calling operations to return NaN. Function will recalculate
+ * element's size in [ms] interval.
  * @returns {Point}
  * @private
  */
-function _getSafeElemSize (oElement) {
+function _getSafeElemSize (oElement, interval) {
     if(oElement.oldClientWidth !== undefined && oElement.oldClientHeight !== undefined){
         var safeSize = new $.Point(oElement.oldClientWidth, oElement.oldClientHeight);
 
         var currentTime = new Date().getTime();
-        if(currentTime - oElement.recentCalculationTime > 10000){
+        if(currentTime - oElement.recentCalculationTime > interval){
             delete oElement.oldClientWidth;
             delete oElement.oldClientHeight;
         }
@@ -3304,7 +3304,7 @@ function updateOnce( viewer ) {
     }
 
     if (viewer.autoResize) {
-        var containerSize = _getSafeElemSize(viewer.container);
+        var containerSize = _getSafeElemSize(viewer.container, viewer.autoResizeInterval);
         var prevContainerSize = THIS[viewer.hash].prevContainerSize;
         if (!containerSize.equals(prevContainerSize)) {
             var viewport = viewer.viewport;


### PR DESCRIPTION
Added throttling mechanism into its implementation to limit so frequent DOM reads (and layout trashing) with calling .clientWidth and .clientHeight. 5 seconds interval is defined as default. 